### PR TITLE
Added setProgressNumberFormat method

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+[*.java]
+indent_style = tab
+indent_size = 4
+

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requirements
 Installation
 -------------
     cordova plugin add cordova-plugin-pdialog
-    
+
 Simple Usage
 -------------
 show:
@@ -51,12 +51,15 @@ These are the valid options:
 
 `message`: contents of the progress dialog (defaults to empty)
 
+`format`: the small text showing current and maximum units of progress (defaults to %1d/%2d)
+
     cordova.plugin.pDialog.init({
         theme : 'HOLO_DARK',
         progressStyle : 'SPINNER',
         cancelable : true,
         title : 'Please Wait...',
-        message : 'Contacting server ...'
+        message : 'Contacting server ...',
+        format: '%1d - %2d'
     });
 
 ###.dismiss()
@@ -68,31 +71,38 @@ Dismiss the progress dialog.
 ###.setProgress(_int_)
 
 Set the value of the progress bar when progressStyle is `HORIZONTAL`.
-    
+
     cordova.plugin.pDialog.init({progressStyle : 'HORIZONTAL', title: 'Please Wait...', message : 'Connecting to server...'});
     cordova.plugin.pDialog.setProgress(25);
-    
+
 ![pDialog2](http://i.imgur.com/7k2docz.png)
 
 
 ###.setTitle(_title_)
 
 Set the title of the progress dialog.
-    
+
     cordova.plugin.pDialog.setTitle('Please Wait...');
-    
+
 ###.setMessage(_message_)
 
 Set the message of the progress dialog
 
-    cordova.plugin.pDialog.setMessage('Connecting to server...');   
-    
+    cordova.plugin.pDialog.setMessage('Connecting to server...');
+
 ###.setCancelable(_boolean_)
 
 Set whether the progress dialog is calncelable or not (defaults to `true`)
 
-    cordova.plugin.pDialog.setCancelable(false); // The user can not cancel the progress dialog  
-    
+    cordova.plugin.pDialog.setCancelable(false); // The user can not cancel the progress dialog
+
+###.setProgressNukberFormat(_format_)
+
+Set the text showing the current and maximum units of progress
+
+    cordova.plugin.pDialog.setProgressNumberFormat('%1d - %2d');
+
+
 
 Chaining The Functions
 -----------------------
@@ -131,4 +141,4 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-    
+

--- a/src/android/io/github/pwlin/cordova/plugins/pdialog/PDialog.java
+++ b/src/android/io/github/pwlin/cordova/plugins/pdialog/PDialog.java
@@ -68,13 +68,15 @@ public class PDialog extends CordovaPlugin {
 			this.setMessage(rawArgs);
 		} else if (action.equals("setCancelable")) {
 			this.setCancelable(rawArgs);
-		}
+		} else if (action.equals("setProgressNumberFormat")) {
+            this.setProgressNumberFormat(rawArgs);
+        }
 		return true;
 	}
 
 	/**
 	 * Initializing the progress dialog and set various parameters
-	 * 
+	 *
 	 * @param rawArgs
 	 * @see https://github.com/pwlin/cordova-plugin-pdialog/blob/master/README.md
 	 */
@@ -155,12 +157,22 @@ public class PDialog extends CordovaPlugin {
 					}
 				}
 
+                String format = "";
+				if (argsObj.has("format")) {
+					try {
+					    format = argsObj.getString("format");
+					} catch (JSONException e) {
+						// e.printStackTrace();
+					}
+				}
+
 				PDialog.pDialogObj = new ProgressDialog(cordova.getActivity(), theme);
 				PDialog.pDialogObj.setProgressStyle(style);
 				PDialog.pDialogObj.setCancelable(cancelable);
 				PDialog.pDialogObj.setCanceledOnTouchOutside(cancelable);
 				PDialog.pDialogObj.setTitle(title);
 				PDialog.pDialogObj.setMessage(message);
+				PDialog.pDialogObj.setProgressNumberFormat(format);
 				PDialog.pDialogObj.show();
 			};
 		};
@@ -182,7 +194,7 @@ public class PDialog extends CordovaPlugin {
 
 	/**
 	 * Set the value of the progress bar when progress style is "HORIZONTAL"
-	 * 
+	 *
 	 * @param rawArgs
 	 */
 	private void setProgress(final String rawArgs) {
@@ -198,7 +210,7 @@ public class PDialog extends CordovaPlugin {
 
 	/**
 	 * Set the title of the progress dialog
-	 * 
+	 *
 	 * @param rawArgs
 	 */
 	private void setTitle(final String title) {
@@ -213,7 +225,7 @@ public class PDialog extends CordovaPlugin {
 
 	/**
 	 * Set the message of the progress dialog
-	 * 
+	 *
 	 * @param rawArgs
 	 */
 	private void setMessage(final String message) {
@@ -228,7 +240,7 @@ public class PDialog extends CordovaPlugin {
 
 	/**
 	 * Set the progress max of the progress dialog
-	 * 
+	 *
 	 * @param rawArgs
 	 */
 	private void setMax(final String max) {
@@ -243,7 +255,7 @@ public class PDialog extends CordovaPlugin {
 
 	/**
 	 * Set whether the progress dialog is calncelable or not
-	 * 
+	 *
 	 * @param rawArgs
 	 */
 	private void setCancelable(final String rawArgs) {
@@ -258,4 +270,18 @@ public class PDialog extends CordovaPlugin {
 		this.cordova.getActivity().runOnUiThread(runnable);
 	}
 
+    /**
+	 * Change the format of the small text showing current and maximum units of progress.
+	 *
+	 * @param rawArgs
+	 */
+	private void setProgressNumberFormat(final String format) {
+		Runnable runnable = new Runnable() {
+			@Override
+			public void run() {
+				PDialog.pDialogObj.setProgressNumberFormat(format);
+			};
+		};
+		this.cordova.getActivity().runOnUiThread(runnable);
+	}
 }

--- a/src/android/io/github/pwlin/cordova/plugins/pdialog/PDialog.java
+++ b/src/android/io/github/pwlin/cordova/plugins/pdialog/PDialog.java
@@ -157,7 +157,7 @@ public class PDialog extends CordovaPlugin {
 					}
 				}
 
-                String format = "";
+				String format = "";
 				if (argsObj.has("format")) {
 					try {
 					    format = argsObj.getString("format");

--- a/www/plugins.PDialog.js
+++ b/www/plugins.PDialog.js
@@ -43,13 +43,16 @@ function PDialog() {}
  *
  *  "message": contents of the progress dialog (defaults to empty)
  *
+ *  "format": the small text showing current and maximum units of progress (defaults to %1d/%2d)
+ *
  *  @example
  *  cordova.plugin.pDialog.init({
  *      theme : 'HOLO_DARK',
  *      progressStyle: 'SPINNER',
  *      cancelable : false,
  *      title: 'Please Wait...',
- *      message: 'Contacting server ...'
+ *      message: 'Contacting server ...',
+ *      format: '%1d - %2d'
  *  });
  *
  */
@@ -111,5 +114,14 @@ PDialog.prototype.setCancelable = function (flag) {
     exec(null, null, 'PDialog', 'setCancelable', flag);
     return this;
 };
+
+/**
+ * Change the format of the small text showing current and maximum units of progress.
+ * @param {String} format
+ */
+PDialog.prototype.setProgressNumberFormat = function (format) {
+    exec(null, null, 'PDialog', 'setProgressNumberFormat', format);
+    return this;
+}
 
 module.exports = new PDialog();


### PR DESCRIPTION
Change the format of the small text showing current and maximum units of progress. The default is "%1d/%2d". Should not be called during the number is progressing.
